### PR TITLE
feat: adicionada infraestrutura para hospedar o sonarqube

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - develop
+      - main
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,92 @@
+name: 'Terraform'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - develop
+
+  workflow_dispatch:
+    inputs:
+      # Terraform action you want to perform
+      action:
+        description: 'Terraform Action to Perform'
+        type: choice
+        options:
+          - terraform
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS Credentials Action For GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+
+      - name: Update Pull Request
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: ${{ steps.plan.outputs.stdout }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`terraform\n
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve -input=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# sonarqube
+## SOAT1 - Grupo 5 - Infra Sonarqube
+
+Repositório Terraform para administrar a infra do Sonarqube do projeto Tech Challenge.
+
+O repositório foi baseado no [tutorial](https://www.youtube.com/watch?v=cVVfZkQpyQ8), com modificações aplicadas para o deploy usando Github Actions.
+
+- Obs: demonstração do vídeo

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,20 @@
+# Declaring the AWS Provider
+provider "aws" {
+  region = "us-east-1"
+}
+
+
+
+resource "aws_instance" "Sonarqube" {
+  ami                    = "ami-0557a15b87f6559cf" # free tier AMI image
+  instance_type          = "t2.medium"
+  user_data              = file("sonar_script.sh")
+  vpc_security_group_ids = [aws_security_group.ec2.id]
+  key_name               = "vockey" # Existing ssh key 
+
+  tags = {
+    Name = "Sonarqube_Instance"
+  }
+}
+
+

--- a/security.tf
+++ b/security.tf
@@ -1,0 +1,20 @@
+resource "aws_security_group" "ec2" {
+  name        = "allow_sonar"
+  description = "Allow sonar outbound traffic"
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Name = "allow_sonar"
+  }
+}

--- a/sonar_script.sh
+++ b/sonar_script.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Increase the vm.max_map_count for kernel and ulimit for the current session at runtime.
+sudo bash -c 'cat <<EOT> /etc/sysctl.conf
+vm.max_map_count=524288
+fs.file-max=131072
+ulimit -n 65536
+ulimit -u 4096
+EOT'
+sudo sysctl -w vm.max_map_count=524288
+sysctl -w fs.file-max=131072
+
+#Increase these permanently
+sudo bash -c 'cat <<EOT> /etc/security/limits.conf
+sonarqube   -   nofile   65536
+sonarqube   -   nproc    4096
+EOT'
+
+# Need JDK 17 or higher to run SonarQube 9.9
+sudo apt-get update -y
+sudo apt-get install openjdk-17-jdk -y
+sudo update-alternatives --config java
+java -version
+
+
+# Install and configure PostgreSQL & Create a user and database for sonar
+wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+sudo apt install postgresql postgresql-contrib -y
+sudo systemctl enable postgresql.service
+sudo systemctl start  postgresql.service
+sudo echo "postgres:admin123" | chpasswd
+runuser -l postgres -c "createuser sonar"
+sudo -i -u postgres psql -c "ALTER USER sonar WITH ENCRYPTED PASSWORD 'admin123';"
+sudo -i -u postgres psql -c "CREATE DATABASE sonarqube OWNER sonar;"
+sudo -i -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE sonarqube to sonar;"
+sudo systemctl restart  postgresql
+
+
+#Download the binaries for SonarQube 
+sudo mkdir -p /sonarqube/
+cd /sonarqube/
+sudo curl -O https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-9.9.3.79811.zip
+sudo apt-get install zip -y
+sudo unzip -o sonarqube-9.9.3.79811.zip -d /opt/
+sudo mv /opt/sonarqube-9.9.3.79811/ /opt/sonarqube
+sudo rm -rf /opt/sonarqube/conf/sonar.properties
+sudo touch /opt/sonarqube/conf/sonar.properties
+
+# PostgreSQL database username and password
+sudo bash -c 'cat <<EOT> /opt/sonarqube/conf/sonar.properties
+sonar.jdbc.username=sonar
+sonar.jdbc.password=admin123
+sonar.jdbc.url=jdbc:postgresql://localhost/sonarqube
+sonar.web.host=0.0.0.0
+sonar.web.port=9000
+sonar.web.javaAdditionalOpts=-server
+sonar.search.javaOpts=-Xmx512m -Xms512m -XX:+HeapDumpOnOutOfMemoryError
+sonar.log.level=INFO
+sonar.path.logs=logs
+EOT'
+# Create the group
+sudo groupadd sonar
+sudo useradd -c "SonarQube - User" -d /opt/sonarqube/ -g sonar sonar
+sudo chown sonar:sonar /opt/sonarqube/ -R
+
+# Create a systemd service file for SonarQube to run at system startup
+sudo touch /etc/systemd/system/sonarqube.service
+sudo bash -c 'cat <<EOT> /etc/systemd/system/sonarqube.service
+[Unit]
+Description=SonarQube service
+After=syslog.target network.target
+
+[Service]
+Type=forking
+
+ExecStart=/opt/sonarqube/bin/linux-x86-64/sonar.sh start
+ExecStop=/opt/sonarqube/bin/linux-x86-64/sonar.sh stop
+
+User=sonar
+Group=sonar
+Restart=always
+
+LimitNOFILE=65536
+LimitNPROC=4096
+
+
+[Install]
+WantedBy=multi-user.target
+EOT'
+
+# automatically system startup enable
+sudo systemctl daemon-reload
+sudo systemctl enable sonarqube.service
+
+# Install and configure Nginx as a reverse proxy for SonarQube.
+
+apt-get install nginx -y
+sudo rm -rf /etc/nginx/sites-enabled/default
+sudo rm -rf /etc/nginx/sites-available/default
+sudo touch /etc/nginx/sites-available/sonarqube
+sudo bash -c 'sudo cat <<EOT> /etc/nginx/sites-available/sonarqube
+server{
+    listen      80;
+    server_name sonar.robofarming.link;
+
+    access_log  /var/log/nginx/sonar.access.log;
+    error_log   /var/log/nginx/sonar.error.log;
+
+    proxy_buffers 16 64k;
+    proxy_buffer_size 128k;
+
+    location / {
+        proxy_pass  http://127.0.0.1:9000;
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_redirect off;
+              
+        proxy_set_header    Host            \$host;
+        proxy_set_header    X-Real-IP       \$remote_addr;
+        proxy_set_header    X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto http;
+    }
+}
+EOT'
+ln -s /etc/nginx/sites-available/sonarqube /etc/nginx/sites-enabled/sonarqube
+
+# Automatically system startup enable
+sudo systemctl enable nginx.service
+sudo systemctl restart nginx.service
+sudo systemctl restart sonarqube.service

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+
+  backend "s3" {
+    bucket         = "soat1-terraform-state-lock"
+    key            = "rds/main.tf"
+    region         = "us-east-1"
+    profile        = "default"
+    encrypt        = true
+    dynamodb_table = "terraform-state-lock"
+  }
+}


### PR DESCRIPTION
# Observações
- O sonarqube está rodando na aws que a fiap disponibilizou, então talvez se testarem ele esteja fora do ar (ela para tudo após 4hrs de uso), mas vou enviar os dados de acesso posteriormente pra vocês poderem reativar.
- Eu vi vários tutoriais relacionados a subir o sonarqube (já que a versão com cloud própria é apenas a paga) e esse foi o mais simples que eu encontrei, basicamente tudo que precisa está sendo instalado dentro de uma máquina EC2. 
- Vocês vão ver que tem usuário e senha no script, mas isso é apenas para um primeiro acesso, a senha já foi trocada e também vou passar.
- Eu deixei as regras como default, mas podemos discutir depois se quiserem mudar.

Apenas para fins de registro, a url é essa daqui: http://3.89.160.194/